### PR TITLE
Fixes warning logging.

### DIFF
--- a/src/leap/bitmask/core/mail_services.py
+++ b/src/leap/bitmask/core/mail_services.py
@@ -582,7 +582,7 @@ class StandardMailService(service.MultiService, HookableService):
             try:
                 shutil.rmtree(tokens_folder)
             except OSError as e:
-                logger.warning("Can't remove tokens folder %s: %s"
+                logger.warn("Can't remove tokens folder %s: %s"
                                % (tokens_folder, e))
                 return
         os.mkdir(tokens_folder, 0700)

--- a/src/leap/bitmask/mail/adaptors/soledad.py
+++ b/src/leap/bitmask/mail/adaptors/soledad.py
@@ -504,7 +504,7 @@ class MessageWrapper(object):
             for (key, doc) in cdocs.items()])
         for doc_id, cdoc in zip(self.mdoc.cdocs, self.cdocs.values()):
             if cdoc.raw == "":
-                logger.warning("Empty raw field in cdoc %s" % doc_id)
+                logger.warn("Empty raw field in cdoc %s" % doc_id)
             cdoc.set_future_doc_id(doc_id)
 
     def create(self, store, notify_just_mdoc=False, pending_inserts_dict=None):
@@ -1125,7 +1125,7 @@ class SoledadMailAdaptor(SoledadIndexMixin):
 
         def get_mdoc_id(hdoc):
             if not hdoc:
-                logger.warning("Could not find a HDOC with MSGID %s" % msgid)
+                logger.warn("Could not find a HDOC with MSGID %s" % msgid)
                 return None
             hdoc = hdoc[0]
             mdoc_id = hdoc.doc_id.replace("H-", "M-%s-" % uuid)


### PR DESCRIPTION
Following Twisted documentation, I found out that the `warning` method doesn't exist on logger class. That class has `warn` method instead. And I got a error because of that.

https://twistedmatrix.com/documents/16.4.1/api/twisted.logger.Logger.html

❤️
